### PR TITLE
netkvm: avoid crash on second virtqueue shutdown

### DIFF
--- a/NetKVM/Common/ParaNdis-VirtQueue.h
+++ b/NetKVM/Common/ParaNdis-VirtQueue.h
@@ -171,7 +171,7 @@ public:
 
     void Shutdown()
     {
-        if (CanTouchHardware())
+        if (m_VirtQueue && CanTouchHardware())
         {
             virtqueue_shutdown(m_VirtQueue);
         }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1791153
In hot unplug flow the Shutdown() was called when
the m_VirtQueue already zeroed. Avoid NULL pointer
dereferencing.

Signed-off-by: Yuri Benditovich <yuri.benditovich@daynix.com>